### PR TITLE
8 testing  data scale and performance limits

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,6 @@ export default function App() {
   // Load the built-in sample data
   const handleLoadSample = useCallback(() => {
     setError(null);
-    const data = parseAnyGraphInput(scrapyDeps);
     const data = generateSampleData();
     setGraphData(data);
     setSelectedNode(null);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import NodeInfo from './components/NodeInfo';
 import { useForceConfig } from './hooks/useForceConfig';
 import { generateSampleData, parseAnyGraphInput, fetchGraphData } from './data/sampleData';
 import scrapyDeps from './data/scrapy-deps.json';
+import { StressBench } from './components/StressBench';
 
 /**
  * App Component
@@ -17,9 +18,9 @@ export default function App() {
   const [selectedNode, setSelectedNode] = useState(null);
   const [error, setError] = useState(null);
   const [resetViewTrigger, setResetViewTrigger] = useState(0);
-
+ 
   const { config, updateConfig } = useForceConfig();
-
+ 
   // Load the built-in sample data
   const handleLoadSample = useCallback(() => {
     setError(null);
@@ -27,7 +28,7 @@ export default function App() {
     setGraphData(data);
     setSelectedNode(null);
   }, []);
-
+ 
   // Load data from an API endpoint
   const handleLoadFromAPI = useCallback(async (url) => {
     setError(null)
@@ -36,7 +37,7 @@ export default function App() {
       if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.links)) {
         throw new Error('Invalid graph format: missing nodes or links')
       }
-
+ 
       if (data.nodes.length === 0) {
         throw new Error('Invalid graph format: nodes cannot be empty')
       }
@@ -47,53 +48,53 @@ export default function App() {
       console.error(err)
     }
   }, [])
-
+ 
   // Load data from an uploaded JSON file
   const handleFileUpload = useCallback((file) => {
     setError(null);
-
+ 
     if (!file) {
       setError('No file selected');
       return;
     }
-
+ 
     const reader = new FileReader();
-
+ 
     reader.onload = (e) => {
       try {
         const text = e.target?.result;
-
+ 
         if (typeof text !== 'string') {
           throw new Error('Failed to read file');
         }
-
+ 
         const json = JSON.parse(text);
-
+ 
         const hasGraphFormat =
           json &&
           Array.isArray(json.nodes) &&
           Array.isArray(json.links);
-
+ 
         const hasTimeSlicedFormat =
           json &&
           Array.isArray(json.timeSlices);
-
+ 
         if (!hasGraphFormat && !hasTimeSlicedFormat) {
           throw new Error(
             'Unsupported JSON format. Expected either graph format or time-sliced format.'
           );
         }
-
+ 
         const data = parseAnyGraphInput(json);
-
+ 
         if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.links)) {
           throw new Error('Failed to parse graph data');
         }
-
+ 
         if (data.nodes.length === 0) {
           throw new Error('Invalid graph format: nodes cannot be empty');
         }
-
+ 
         const nodeIds = new Set();
         for (const node of data.nodes) {
           if (nodeIds.has(node.id)) {
@@ -101,29 +102,29 @@ export default function App() {
           }
           nodeIds.add(node.id);
         }
-
+ 
         const nodeMap = new Map(data.nodes.map((n) => [n.id, n]));
-
+ 
         for (const link of data.links) {
           const sourceId = typeof link.source === 'object' ? link.source.id : link.source;
           const targetId = typeof link.target === 'object' ? link.target.id : link.target;
-
+ 
           if (!sourceId || !targetId) {
             throw new Error('Invalid links: missing source or target');
           }
-
+ 
           if (!nodeMap.has(sourceId) || !nodeMap.has(targetId)) {
             throw new Error('Invalid link: source or target node does not exist');
           }
-
+ 
           const sourceNode = nodeMap.get(sourceId);
           const targetNode = nodeMap.get(targetId);
-
+ 
           if (sourceNode.layer > targetNode.layer) {
             throw new Error('Invalid edge: backward-pointing edges are not allowed');
           }
         }
-
+ 
         setGraphData(data);
         setSelectedNode(null);
         setError(null);
@@ -132,19 +133,19 @@ export default function App() {
         console.error(err);
       }
     };
-
+ 
     reader.onerror = () => {
       setError('Failed to read file');
     };
-
+ 
     reader.readAsText(file);
   }, []);
-
+ 
   const handleResetView = useCallback(() => {
     setResetViewTrigger((prev) => prev + 1);
   }, []);
-
-
+ 
+ 
   return (
     <div className="app-container">
       {/* 3D Graph Viewport */}
@@ -156,10 +157,13 @@ export default function App() {
           selectedNode={selectedNode}
           resetViewTrigger={resetViewTrigger}
         />
-
+ 
         {/* Selected node info overlay */}
         <NodeInfo node={selectedNode} />
-
+ 
+        {/* Stress-test overlay (top-left) */}
+        <StressBench onLoadGraph={setGraphData} />
+ 
         {/* Error banner */}
         {error && (
           <div
@@ -181,7 +185,7 @@ export default function App() {
           </div>
         )}
       </div>
-
+ 
       {/* Side Panel */}
       <ControlPanel
         config={config}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,6 @@ import ControlPanel from './components/ControlPanel';
 import NodeInfo from './components/NodeInfo';
 import { useForceConfig } from './hooks/useForceConfig';
 import { generateSampleData, parseAnyGraphInput, fetchGraphData } from './data/sampleData';
-import scrapyDeps from './data/scrapy-deps.json';
-import { StressBench } from './components/StressBench';
 
 /**
  * App Component
@@ -25,6 +23,7 @@ export default function App() {
   const handleLoadSample = useCallback(() => {
     setError(null);
     const data = parseAnyGraphInput(scrapyDeps);
+    const data = generateSampleData();
     setGraphData(data);
     setSelectedNode(null);
   }, []);
@@ -160,10 +159,7 @@ export default function App() {
  
         {/* Selected node info overlay */}
         <NodeInfo node={selectedNode} />
- 
-        {/* Stress-test overlay (top-left) */}
-        <StressBench onLoadGraph={setGraphData} />
- 
+
         {/* Error banner */}
         {error && (
           <div
@@ -194,6 +190,7 @@ export default function App() {
         onLoadFromAPI={handleLoadFromAPI}
         onFileUpload={handleFileUpload}
         onResetView={handleResetView}
+        onLoadGraph={setGraphData}
       />
     </div>
   );

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
+import { StressBench } from './StressBench';
 
 /**
  * ControlPanel Component
  *
  * Provides sliders and controls for tuning force simulation parameters,
  * data source selection, and API endpoint input.
+ *
+ * Now also hosts a "Benchmark" tab that loads the StressBench overlay
+ * inline rather than as a floating panel.
  */
 export default function ControlPanel({
   config,
@@ -13,8 +17,10 @@ export default function ControlPanel({
   onLoadFromAPI,
   onFileUpload,
   onResetView,
+  onLoadGraph,            // ← new: passed straight to StressBench
 }) {
   const [collapsed, setCollapsed] = useState(false);
+  const [tab, setTab] = useState('controls'); // 'controls' | 'bench'
 
   return (
     <div className={`control-panel${collapsed ? ' collapsed' : ''}`}>
@@ -33,163 +39,203 @@ export default function ControlPanel({
 
       {!collapsed && (
         <>
-          {/* Data Source */}
-          <div className="panel-section">
-            <h2>Data Source</h2>
-            <div className="btn-group">
-              <button className="btn btn-primary" onClick={onLoadSample}>
-                Load Sample
-              </button>
-              <label className="btn" style={{ cursor: 'pointer' }}>
-                Upload JSON
-                <input
-                  type="file"
-                  accept=".json"
-                  style={{ display: 'none' }}
-                  onChange={(e) => {
-                    const file = e.target.files?.[0];
-                    if (file && onFileUpload) onFileUpload(file);
-                    e.target.value = '';
-                  }}
-                />
-              </label>
-            </div>
-
-            {/* API Endpoint */}
-            <div className="api-input-group">
-              <input
-                type="text"
-                placeholder="https://api.example.com/graph"
-                id="api-url-input"
-              />
-              <button
-                className="btn"
-                onClick={() => {
-                  const url = document.getElementById('api-url-input')?.value;
-                  if (url && onLoadFromAPI) onLoadFromAPI(url);
-                }}
-              >
-                Fetch
-              </button>
-            </div>
+          {/* Tab switcher */}
+          <div className="panel-tabs">
+            <button
+              className={`panel-tab${tab === 'controls' ? ' active' : ''}`}
+              onClick={() => setTab('controls')}
+            >
+              Controls
+            </button>
+            <button
+              className={`panel-tab${tab === 'bench' ? ' active' : ''}`}
+              onClick={() => setTab('bench')}
+            >
+              Benchmark
+            </button>
           </div>
 
-          {/* Force Parameters */}
-          <div className="panel-section">
-            <h2>Force Settings</h2>
+          {/*
+            Both tab panes are always rendered so StressBench keeps measuring
+            FPS/memory/convergence even while you're on the Controls tab.
+            The inactive pane is just hidden with `display: none`.
+          */}
+          <div style={{ display: tab === 'controls' ? 'block' : 'none' }}>
+              {/* Data Source */}
+              <div className="panel-section">
+                <h2>Data Source</h2>
+                <div className="btn-group">
+                  <button className="btn btn-primary" onClick={onLoadSample}>
+                    Load Sample
+                  </button>
+                  <label className="btn" style={{ cursor: 'pointer' }}>
+                    Upload JSON
+                    <input
+                      type="file"
+                      accept=".json"
+                      style={{ display: 'none' }}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file && onFileUpload) onFileUpload(file);
+                        e.target.value = '';
+                      }}
+                    />
+                  </label>
+                </div>
 
-            <div className="slider-control">
-              <div className="slider-label">
-                <span>Repulsion Strength</span>
-                <span className="value">{config.repulsionStrength}</span>
+                {/* API Endpoint */}
+                <div className="api-input-group">
+                  <input
+                    type="text"
+                    placeholder="https://api.example.com/graph"
+                    id="api-url-input"
+                  />
+                  <button
+                    className="btn"
+                    onClick={() => {
+                      const url = document.getElementById('api-url-input')?.value;
+                      if (url && onLoadFromAPI) onLoadFromAPI(url);
+                    }}
+                  >
+                    Fetch
+                  </button>
+                </div>
               </div>
-              <input
-                type="range"
-                min={0}
-                max={500}
-                step={1}
-                value={config.repulsionStrength}
-                onChange={(e) => updateConfig('repulsionStrength', Number(e.target.value))}
-              />
-            </div>
 
-            <div className="slider-control">
-              <div className="slider-label">
-                <span>Repulsion Range</span>
-                <span className="value">{config.repulsionMaxDistance}</span>
-              </div>
-              <input
-                type="range"
-                min={50}
-                max={1500}
-                step={10}
-                value={config.repulsionMaxDistance}
-                onChange={(e) => updateConfig('repulsionMaxDistance', Number(e.target.value))}
-              />
-            </div>
+              {/* Force Parameters */}
+              <div className="panel-section">
+                <h2>Force Settings</h2>
 
-            <div className="slider-control">
-              <div className="slider-label">
-                <span>Spring Strength</span>
-                <span className="value">{config.springStrength.toFixed(2)}</span>
-              </div>
-              <input
-                type="range"
-                min={0}
-                max={0.5}
-                step={0.01}
-                value={config.springStrength}
-                onChange={(e) => updateConfig('springStrength', Number(e.target.value))}
-              />
-            </div>
+                <div className="slider-control">
+                  <div className="slider-label">
+                    <span>Repulsion Strength</span>
+                    <span className="value">{config.repulsionStrength}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={500}
+                    step={1}
+                    value={config.repulsionStrength}
+                    onChange={(e) => updateConfig('repulsionStrength', Number(e.target.value))}
+                  />
+                </div>
 
-            <div className="slider-control">
-              <div className="slider-label">
-                <span>Spring Rest Length</span>
-                <span className="value">{config.springRestLength}</span>
-              </div>
-              <input
-                type="range"
-                min={1}
-                max={100}
-                step={1}
-                value={config.springRestLength}
-                onChange={(e) => updateConfig('springRestLength', Number(e.target.value))}
-              />
-            </div>
+                <div className="slider-control">
+                  <div className="slider-label">
+                    <span>Repulsion Range</span>
+                    <span className="value">{config.repulsionMaxDistance}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={50}
+                    max={1500}
+                    step={10}
+                    value={config.repulsionMaxDistance}
+                    onChange={(e) => updateConfig('repulsionMaxDistance', Number(e.target.value))}
+                  />
+                </div>
 
-            <div className="slider-control">
-              <div className="slider-label">
-                <span>Damping</span>
-                <span className="value">{config.damping.toFixed(2)}</span>
+                <div className="slider-control">
+                  <div className="slider-label">
+                    <span>Spring Strength</span>
+                    <span className="value">{config.springStrength.toFixed(2)}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={0.5}
+                    step={0.01}
+                    value={config.springStrength}
+                    onChange={(e) => updateConfig('springStrength', Number(e.target.value))}
+                  />
+                </div>
+
+                <div className="slider-control">
+                  <div className="slider-label">
+                    <span>Spring Rest Length</span>
+                    <span className="value">{config.springRestLength}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={1}
+                    max={100}
+                    step={1}
+                    value={config.springRestLength}
+                    onChange={(e) => updateConfig('springRestLength', Number(e.target.value))}
+                  />
+                </div>
+
+                <div className="slider-control">
+                  <div className="slider-label">
+                    <span>Damping</span>
+                    <span className="value">{config.damping.toFixed(2)}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={config.damping}
+                    onChange={(e) => updateConfig('damping', Number(e.target.value))}
+                  />
+                </div>
               </div>
-              <input
-                type="range"
-                min={0}
-                max={1}
-                step={0.01}
-                value={config.damping}
-                onChange={(e) => updateConfig('damping', Number(e.target.value))}
-              />
-            </div>
+
+              {/* Layout */}
+              <div className="panel-section">
+                <h2>Layout</h2>
+
+                <div className="slider-control">
+                  <div className="slider-label">
+                    <span>Layer Spacing</span>
+                    <span className="value">{config.layerSpacing}</span>
+                  </div>
+                  <input
+                    type="range"
+                    min={20}
+                    max={400}
+                    step={5}
+                    value={config.layerSpacing}
+                    onChange={(e) => updateConfig('layerSpacing', Number(e.target.value))}
+                  />
+                </div>
+              </div>
+
+              {/* View Controls */}
+              <div className="panel-section">
+                <h2>View Controls</h2>
+
+                <div className="control-group">
+                  <button
+                    className="btn btn-secondary"
+                    onClick={() => {
+                      if (onResetView) onResetView();
+                    }}
+                  >
+                    Reset View
+                  </button>
+                </div>
+
+              </div>
+
           </div>
 
-          {/* Layout */}
-          <div className="panel-section">
-            <h2>Layout</h2>
-
-            <div className="slider-control">
-              <div className="slider-label">
-                <span>Layer Spacing</span>
-                <span className="value">{config.layerSpacing}</span>
-              </div>
-              <input
-                type="range"
-                min={20}
-                max={400}
-                step={5}
-                value={config.layerSpacing}
-                onChange={(e) => updateConfig('layerSpacing', Number(e.target.value))}
-              />
-            </div>
+          {/*
+            The Benchmark pane is also always mounted. While on the Controls
+            tab a compact "live mini-bar" surfaces from inside it via fixed
+            positioning so you can see FPS/MEM/CONV without leaving Controls.
+          */}
+          <div style={{ display: tab === 'bench' ? 'block' : 'none' }}>
+            <StressBench onLoadGraph={onLoadGraph} showMiniBar={tab !== 'bench'} />
           </div>
-
-          {/* View Controls */}
-          <div className="panel-section">
-            <h2>View Controls</h2>
-
-            <div className="control-group">
-              <button
-                className="btn btn-secondary"
-                onClick={() => {
-                  if (onResetView) onResetView();
-                }}
-              >
-                Reset View
-              </button>
-            </div>
-
-          </div>
+          {/*
+            We render StressBench's mini-bar above by passing showMiniBar.
+            But the *component itself* must remain mounted in only one place
+            to keep its single source of truth — so we render it always inside
+            the bench pane and let CSS hide it. The mini-bar is rendered
+            internally as a fixed-position element when showMiniBar is true.
+          */}
 
         </>
       )}

--- a/src/components/StressBench.jsx
+++ b/src/components/StressBench.jsx
@@ -1,29 +1,24 @@
 /**
  * StressBench.jsx
  * ─────────────────────────────────────────────────────────────────────────────
- * A fixed-position overlay panel that:
- *   1. Lets you load any preset (or custom) benchmark scenario into the renderer
- *   2. Measures live FPS via requestAnimationFrame
- *   3. Reports JS heap usage via performance.memory (Chromium only; null elsewhere)
- *   4. Times simulation convergence by detecting when FPS stabilises
- *   5. Logs every run to a results table you can eyeball for threshold hunting
- *   6. Auto-runs all presets sequentially ("Run All")
- *   7. Exports results as Markdown (clipboard) or JSON (download) for .md docs
+ * Renders inside the ControlPanel "Benchmark" tab.  Lets you:
+ *   1. Load any preset (or custom) benchmark scenario into the renderer
+ *   2. See live FPS / memory / convergence-time metrics
+ *   3. Auto-run all 8 presets sequentially ("Run all")
+ *   4. Export results as Markdown (clipboard) or JSON (download)
  *
- * ── Integration (two lines in App.jsx) ───────────────────────────────────────
+ * The component takes a single `onLoadGraph` prop — the same setter you'd
+ * normally feed graph data into.
  *
- *   import { StressBench } from './components/StressBench';
+ * Styles live in `./stress-bench.css`. Tweak the `--sb-*` CSS variables to
+ * re-theme the panel.
  *
- *   // Inside the graph-container div, alongside <NodeInfo />:
- *   <StressBench onLoadGraph={setGraphData} />
-
- *
- * ── Convergence heuristic ─────────────────────────────────────────────────────
+ * ── Convergence heuristic ─────────────────────────────────────────────────
  *   We sample FPS every 500 ms.  Once we collect 4 consecutive samples whose
  *   spread (max − min) is ≤ 3 fps we declare the simulation converged.
  *   This works without touching the physics engine internals.
  *
- * ── Threshold hunting guide ──────────────────────────────────────────────────
+ * ── Threshold hunting guide ──────────────────────────────────────────────
  *   • FPS < 30  → "struggling"  (orange)
  *   • FPS < 15  → "unusable"    (red)
  *   • Conv = ∞  → simulation never cooled within the 30 s observation window
@@ -69,11 +64,11 @@ const AUTORUN_GAP_MS    = 1500;   // pause between auto-run scenarios
  * @param {{
  *   onLoadGraph: (data: any) => void,
  *   simulationConverged?: boolean,
+ *   showMiniBar?: boolean,
  * }} props
  */
-export function StressBench({ onLoadGraph, simulationConverged }) {
+export function StressBench({ onLoadGraph, simulationConverged, showMiniBar }) {
   // ── UI state ────────────────────────────────────────────────────────────
-  const [open,         setOpen]         = useState(true);
   const [customNodes,  setCustomNodes]  = useState(200);
   const [customLayers, setCustomLayers] = useState(5);
   const [customEdges,  setCustomEdges]  = useState(400);
@@ -431,19 +426,35 @@ export function StressBench({ onLoadGraph, simulationConverged }) {
   const convTier    = !isRunning ? 'dim' : (convMs === null && converged.current ? 'bad' : 'blue');
 
   return (
-    <div className="sb-root">
-      {/* ── Header ── */}
-      <div className="sb-header">
-        <span className="sb-title">⚡ STRESS BENCH</span>
-        <button className="sb-collapse-btn" onClick={() => setOpen(v => !v)}>
-          {open ? '▾' : '▸'}
-        </button>
-      </div>
+    <div className="sb-inline">
+      {/*
+        Mini-bar: fixed-position summary that appears when the user is on
+        the Controls tab (showMiniBar=true) AND a benchmark is running.
+        Lets you tweak Force Settings while still seeing FPS/MEM/CONV update.
+      */}
+      {showMiniBar && isRunning && (
+        <div className="sb-mini-bar">
+          <span className="sb-mini-label">⚡ BENCH</span>
+          <span className={`sb-mini-metric sb-tier-${liveFpsTier}`}>
+            <span className="sb-mini-key">FPS</span>{fps ?? '—'}
+          </span>
+          <span className={`sb-mini-metric sb-tier-${memTier}`}>
+            <span className="sb-mini-key">MEM</span>{memMB ?? '—'}
+          </span>
+          <span className={`sb-mini-metric sb-tier-${convTier}`}>
+            <span className="sb-mini-key">CONV</span>
+            {convMs !== null ? `${convMs}ms` : converged.current ? '∞' : `${elapsed}s…`}
+          </span>
+          <button className="sb-mini-stop" onClick={stopBench} title="Stop benchmark">
+            ■
+          </button>
+        </div>
+      )}
 
-      {/* ── Live metrics bar (always visible) ── */}
+      {/* ── Live metrics bar ── */}
       <div className="sb-metrics-row">
-        <MetricBox label="FPS"      value={fps   ?? '—'} tier={liveFpsTier} />
-        <MetricBox label="MEM MB"   value={memMB ?? '—'} tier={memTier}     />
+        <MetricBox label="FPS"    value={fps   ?? '—'} tier={liveFpsTier} />
+        <MetricBox label="MEM MB" value={memMB ?? '—'} tier={memTier}     />
         <MetricBox
           label="CONV ms"
           value={
@@ -468,134 +479,130 @@ export function StressBench({ onLoadGraph, simulationConverged }) {
         </div>
       )}
 
-      {open && (
-        <>
-          {/* ── Run All button ── */}
-          <div className="sb-group">
+      {/* ── Run All button ── */}
+      <div className="sb-group">
+        <button
+          className="sb-btn sb-btn--run-all"
+          onClick={runAll}
+          disabled={autoRun.active}
+        >
+          ▶▶ Run all 8 presets
+        </button>
+      </div>
+
+      {/* ── Preset groups ── */}
+      {['nodes', 'density', 'layers'].map(group => (
+        <div key={group} className="sb-group">
+          <div className="sb-group-label">{GROUP_LABELS[group]}</div>
+          {PRESETS.filter(p => p.group === group).map((p, i) => (
             <button
-              className="sb-btn sb-btn--run-all"
-              onClick={runAll}
+              key={i}
+              className="sb-btn"
+              onClick={() => loadScenario(p.nodes, p.layers, p.edges, p.label, p.group)}
               disabled={autoRun.active}
             >
-              ▶▶ Run all 8 presets
+              {p.label}
+            </button>
+          ))}
+        </div>
+      ))}
+
+      {/* ── Custom sliders ── */}
+      <div className="sb-group">
+        <div className="sb-group-label">✦ Custom</div>
+        <SliderRow
+          label={`Nodes: ${customNodes.toLocaleString()}`}
+          min={1} max={6000} step={1}
+          value={customNodes} onChange={setCustomNodes}
+        />
+        <SliderRow
+          label={`Layers: ${customLayers}`}
+          min={1} max={60} step={1}
+          value={customLayers} onChange={setCustomLayers}
+        />
+        <SliderRow
+          label={`Edges: ${customEdges.toLocaleString()}`}
+          min={0} max={10000} step={50}
+          value={customEdges} onChange={setCustomEdges}
+        />
+        <div className="sb-btn-row">
+          <button
+            className="sb-btn sb-btn--run"
+            onClick={() =>
+              loadScenario(
+                customNodes, customLayers, customEdges,
+                `${customNodes}n·${customLayers}L·${customEdges}E`,
+                'custom',
+              )
+            }
+            disabled={autoRun.active}
+          >
+            ▶ Run
+          </button>
+          {isRunning && !autoRun.active && (
+            <button className="sb-btn sb-btn--stop" onClick={stopBench}>
+              ■ Stop
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Results table + export ── */}
+      {results.length > 0 && (
+        <div className="sb-group">
+          <div className="sb-results-header">
+            <div className="sb-group-label">Results ({results.length})</div>
+            <button className="sb-clear-btn" onClick={() => setResults([])}>clear</button>
+          </div>
+
+          {/* Export buttons */}
+          <div className="sb-export-row">
+            <button className="sb-btn sb-btn--export" onClick={copyMarkdown}>
+              Copy MD
+            </button>
+            <button className="sb-btn sb-btn--export" onClick={exportJSON}>
+              Export JSON
             </button>
           </div>
+          {exportNotice && <div className="sb-notice">{exportNotice}</div>}
 
-          {/* ── Preset groups ── */}
-          {['nodes', 'density', 'layers'].map(group => (
-            <div key={group} className="sb-group">
-              <div className="sb-group-label">{GROUP_LABELS[group]}</div>
-              {PRESETS.filter(p => p.group === group).map((p, i) => (
-                <button
-                  key={i}
-                  className="sb-btn"
-                  onClick={() => loadScenario(p.nodes, p.layers, p.edges, p.label, p.group)}
-                  disabled={autoRun.active}
-                >
-                  {p.label}
-                </button>
-              ))}
-            </div>
-          ))}
-
-          {/* ── Custom sliders ── */}
-          <div className="sb-group">
-            <div className="sb-group-label">✦ Custom</div>
-            <SliderRow
-              label={`Nodes: ${customNodes.toLocaleString()}`}
-              min={1} max={6000} step={1}
-              value={customNodes} onChange={setCustomNodes}
-            />
-            <SliderRow
-              label={`Layers: ${customLayers}`}
-              min={1} max={60} step={1}
-              value={customLayers} onChange={setCustomLayers}
-            />
-            <SliderRow
-              label={`Edges: ${customEdges.toLocaleString()}`}
-              min={0} max={10000} step={50}
-              value={customEdges} onChange={setCustomEdges}
-            />
-            <div className="sb-btn-row">
-              <button
-                className="sb-btn sb-btn--run"
-                onClick={() =>
-                  loadScenario(
-                    customNodes, customLayers, customEdges,
-                    `${customNodes}n·${customLayers}L·${customEdges}E`,
-                    'custom',
-                  )
-                }
-                disabled={autoRun.active}
-              >
-                ▶ Run
-              </button>
-              {isRunning && !autoRun.active && (
-                <button className="sb-btn sb-btn--stop" onClick={stopBench}>
-                  ■ Stop
-                </button>
-              )}
-            </div>
+          <div className="sb-table-wrap">
+            <table className="sb-table">
+              <thead>
+                <tr>
+                  {['#', 'Scenario', 'N', 'L', 'E', 'FPS', 'MEM', 'Conv ms'].map(h => (
+                    <th key={h}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {results.map(r => (
+                  <tr key={r.id}>
+                    <td>{r.id}</td>
+                    <td className="sb-cell--scenario" title={r.label}>{r.label}</td>
+                    <td>{r.nodes.toLocaleString()}</td>
+                    <td>{r.layers}</td>
+                    <td>{r.edges.toLocaleString()}</td>
+                    <td className={`sb-cell--fps sb-tier-${tierFor(r.fps)}`}>{r.fps}</td>
+                    <td>{r.memMB ?? '—'}</td>
+                    <td className={r.convMs === null ? 'sb-tier-bad' : ''}>
+                      {r.convMs !== null ? r.convMs.toLocaleString() : '∞'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
 
-          {/* ── Results table + export ── */}
-          {results.length > 0 && (
-            <div className="sb-group">
-              <div className="sb-results-header">
-                <div className="sb-group-label">📋 Results ({results.length})</div>
-                <button className="sb-clear-btn" onClick={() => setResults([])}>clear</button>
-              </div>
-
-              {/* Export buttons */}
-              <div className="sb-export-row">
-                <button className="sb-btn sb-btn--export" onClick={copyMarkdown}>
-                  📝 Copy MD
-                </button>
-                <button className="sb-btn sb-btn--export" onClick={exportJSON}>
-                  💾 Export JSON
-                </button>
-              </div>
-              {exportNotice && <div className="sb-notice">{exportNotice}</div>}
-
-              <div className="sb-table-wrap">
-                <table className="sb-table">
-                  <thead>
-                    <tr>
-                      {['#', 'Scenario', 'N', 'L', 'E', 'FPS', 'MEM', 'Conv ms'].map(h => (
-                        <th key={h}>{h}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {results.map(r => (
-                      <tr key={r.id}>
-                        <td>{r.id}</td>
-                        <td className="sb-cell--scenario" title={r.label}>{r.label}</td>
-                        <td>{r.nodes.toLocaleString()}</td>
-                        <td>{r.layers}</td>
-                        <td>{r.edges.toLocaleString()}</td>
-                        <td className={`sb-cell--fps sb-tier-${tierFor(r.fps)}`}>{r.fps}</td>
-                        <td>{r.memMB ?? '—'}</td>
-                        <td className={r.convMs === null ? 'sb-tier-bad' : ''}>
-                          {r.convMs !== null ? r.convMs.toLocaleString() : '∞'}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-
-              {/* Threshold legend */}
-              <div className="sb-hint">
-                FPS colours: <span className="sb-tier-good">≥50 good</span>{' · '}
-                <span className="sb-tier-ok">30–49 ok</span>{' · '}
-                <span className="sb-tier-bad">15–29 struggling</span>{' · '}
-                <span className="sb-tier-dead">&lt;15 unusable</span>
-                {' · '}Conv ∞ = never converged (&gt;30 s)
-              </div>
-            </div>
-          )}
-        </>
+          {/* Threshold legend */}
+          <div className="sb-hint">
+            FPS colours: <span className="sb-tier-good">≥50 good</span>{' · '}
+            <span className="sb-tier-ok">30–49 ok</span>{' · '}
+            <span className="sb-tier-bad">15–29 struggling</span>{' · '}
+            <span className="sb-tier-dead">&lt;15 unusable</span>
+            {' · '}Conv ∞ = never converged (&gt;30 s)
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/StressBench.jsx
+++ b/src/components/StressBench.jsx
@@ -1,0 +1,644 @@
+/**
+ * StressBench.jsx
+ * ─────────────────────────────────────────────────────────────────────────────
+ * A fixed-position overlay panel that:
+ *   1. Lets you load any preset (or custom) benchmark scenario into the renderer
+ *   2. Measures live FPS via requestAnimationFrame
+ *   3. Reports JS heap usage via performance.memory (Chromium only; null elsewhere)
+ *   4. Times simulation convergence by detecting when FPS stabilises
+ *   5. Logs every run to a results table you can eyeball for threshold hunting
+ *   6. Auto-runs all presets sequentially ("Run All")
+ *   7. Exports results as Markdown (clipboard) or JSON (download) for .md docs
+ *
+ * ── Integration (two lines in App.jsx) ───────────────────────────────────────
+ *
+ *   import { StressBench } from './components/StressBench';
+ *
+ *   // Inside the graph-container div, alongside <NodeInfo />:
+ *   <StressBench onLoadGraph={setGraphData} />
+
+ *
+ * ── Convergence heuristic ─────────────────────────────────────────────────────
+ *   We sample FPS every 500 ms.  Once we collect 4 consecutive samples whose
+ *   spread (max − min) is ≤ 3 fps we declare the simulation converged.
+ *   This works without touching the physics engine internals.
+ *
+ * ── Threshold hunting guide ──────────────────────────────────────────────────
+ *   • FPS < 30  → "struggling"  (orange)
+ *   • FPS < 15  → "unusable"    (red)
+ *   • Conv = ∞  → simulation never cooled within the 30 s observation window
+ *   • Tab crash → reduce node count and try again; browser won't report this
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { generateBenchmarkGraph } from '../data/benchmarkDataGenerator';
+// import './stress-bench.css';
+
+// ─── Preset scenarios ────────────────────────────────────────────────────────
+
+const PRESETS = [
+  // Node-count tiers
+  { label: '50 nodes · 3 L · 75 E',       nodes: 50,   layers: 3,  edges: 75,   group: 'nodes'   },
+  { label: '200 nodes · 5 L · 400 E',      nodes: 200,  layers: 5,  edges: 400,  group: 'nodes'   },
+  { label: '1 000 nodes · 8 L · 2 000 E',  nodes: 1000, layers: 8,  edges: 2000, group: 'nodes'   },
+  { label: '5 000 nodes · 8 L · 5 000 E',  nodes: 5000, layers: 8,  edges: 5000, group: 'nodes'   },
+  // Link density (fixed 500 nodes)
+  { label: '500 nodes · 5 L · 50 E',       nodes: 500,  layers: 5,  edges: 50,   group: 'density' },
+  { label: '500 nodes · 5 L · 5 000 E',    nodes: 500,  layers: 5,  edges: 5000, group: 'density' },
+  // Layer extremes
+  { label: '200 nodes · 1 L (repulsion)',   nodes: 200,  layers: 1,  edges: 0,    group: 'layers'  },
+  { label: '200 nodes · 50 L · 300 E',      nodes: 200,  layers: 50, edges: 300,  group: 'layers'  },
+];
+
+const GROUP_LABELS = {
+  nodes:   '↕ Node count tiers',
+  density: '↔ Link density (500 nodes)',
+  layers:  '⊕ Layer extremes',
+};
+
+// ─── FPS stability window ────────────────────────────────────────────────────
+
+const STABILITY_SAMPLES = 4;      // consecutive half-second samples needed
+const STABILITY_SPREAD  = 3;      // max fps spread (max − min) to call it stable
+const CONV_TIMEOUT_MS   = 30_000; // give up after 30 s
+const AUTORUN_GAP_MS    = 1500;   // pause between auto-run scenarios
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+/**
+ * @param {{
+ *   onLoadGraph: (data: any) => void,
+ *   simulationConverged?: boolean,
+ * }} props
+ */
+export function StressBench({ onLoadGraph, simulationConverged }) {
+  // ── UI state ────────────────────────────────────────────────────────────
+  const [open,         setOpen]         = useState(true);
+  const [customNodes,  setCustomNodes]  = useState(200);
+  const [customLayers, setCustomLayers] = useState(5);
+  const [customEdges,  setCustomEdges]  = useState(400);
+
+  // ── Live metrics ─────────────────────────────────────────────────────────
+  const [fps,       setFps]       = useState(null);
+  const [memMB,     setMemMB]     = useState(null);
+  const [convMs,    setConvMs]    = useState(null);   // settled value, null = not yet
+  const [isRunning, setIsRunning] = useState(false);
+  const [elapsed,   setElapsed]   = useState(0);      // seconds since bench start
+
+  // ── Auto-run state ─────────────────────────────────────────────────────
+  const [autoRun,      setAutoRun]      = useState({ active: false, index: 0 });
+  const [exportNotice, setExportNotice] = useState('');
+  const lastResultsLen = useRef(0);
+  const autoTimerRef   = useRef(null);
+
+  // ── Refs (avoid stale closures in rAF loop) ───────────────────────────
+  const rafRef         = useRef(null);
+  const frameCount     = useRef(0);
+  const lastHalfSec    = useRef(performance.now());
+  const benchStart     = useRef(null);
+  const fpsSamples     = useRef([]);
+  const converged      = useRef(false);
+  const prevExternal   = useRef(undefined);
+  const resultCounter  = useRef(0);
+  const pendingMeta    = useRef(null);
+  const resultSaved    = useRef(false);
+
+  // ── Results log ──────────────────────────────────────────────────────────
+  const [results, setResults] = useState([]);
+
+  // ─── rAF measurement loop ───────────────────────────────────────────────
+  const measureLoop = useCallback(() => {
+    frameCount.current++;
+    const now = performance.now();
+
+    // Every 500 ms: compute FPS, check convergence, update elapsed
+    if (now - lastHalfSec.current >= 500) {
+      const dt     = now - lastHalfSec.current;
+      const sample = Math.round((frameCount.current / dt) * 1000);
+
+      setFps(sample);
+      frameCount.current = 0;
+      lastHalfSec.current = now;
+
+      // Memory (Chrome / Chromium only)
+      let mem = null;
+      try { mem = performance.memory; } catch { /* not supported */ }
+      const mb = mem ? Math.round(mem.usedJSHeapSize / 1_048_576) : null;
+      setMemMB(mb);
+
+      // Elapsed seconds
+      if (benchStart.current !== null) {
+        const sec = Math.round((now - benchStart.current) / 1000);
+        setElapsed(sec);
+
+        // Timeout: give up if we haven't converged within 30 s
+        if (!converged.current && now - benchStart.current > CONV_TIMEOUT_MS) {
+          converged.current = true;
+          setConvMs(null); // null signals "never converged"
+        }
+      }
+
+      // FPS-stability heuristic (only while not yet converged)
+      if (!converged.current) {
+        fpsSamples.current.push(sample);
+        if (fpsSamples.current.length > STABILITY_SAMPLES)
+          fpsSamples.current.shift();
+
+        if (fpsSamples.current.length === STABILITY_SAMPLES) {
+          const spread = Math.max(...fpsSamples.current) - Math.min(...fpsSamples.current);
+          if (spread <= STABILITY_SPREAD && benchStart.current !== null) {
+            converged.current = true;
+            const ms = Math.round(now - benchStart.current);
+            setConvMs(ms);
+          }
+        }
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(measureLoop);
+  }, []);
+
+  // Start / stop the rAF loop
+  useEffect(() => {
+    if (isRunning) {
+      rafRef.current = requestAnimationFrame(measureLoop);
+    } else {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    }
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [isRunning, measureLoop]);
+
+  // Optional external convergence signal (only if your renderer exposes one)
+  useEffect(() => {
+    if (
+      simulationConverged === true &&
+      prevExternal.current !== true &&
+      isRunning &&
+      !converged.current &&
+      benchStart.current !== null
+    ) {
+      converged.current = true;
+      setConvMs(Math.round(performance.now() - benchStart.current));
+    }
+    prevExternal.current = simulationConverged;
+  }, [simulationConverged, isRunning]);
+
+  // Auto-save result once we have stable FPS + convergence decision
+  useEffect(() => {
+    if (!isRunning || resultSaved.current || !converged.current) return;
+    if (fps === null || pendingMeta.current === null) return;
+
+    const result = {
+      id: ++resultCounter.current,
+      ...pendingMeta.current,
+      fps,
+      memMB,
+      convMs,
+      time: new Date().toLocaleTimeString(),
+    };
+    setResults(prev => [result, ...prev.slice(0, 49)]); // keep latest 50
+    resultSaved.current = true;
+  }, [fps, memMB, convMs, isRunning]);
+
+  // ─── Auto-run advancer ──────────────────────────────────────────────────
+  // When auto-run is active and a result lands, schedule the next preset.
+  useEffect(() => {
+    if (!autoRun.active) {
+      lastResultsLen.current = results.length;
+      return;
+    }
+    if (results.length > lastResultsLen.current) {
+      lastResultsLen.current = results.length;
+      const nextIdx = autoRun.index + 1;
+
+      if (nextIdx >= PRESETS.length) {
+        setAutoRun({ active: false, index: 0 });
+        setIsRunning(false);
+        return;
+      }
+
+      autoTimerRef.current = setTimeout(() => {
+        const p = PRESETS[nextIdx];
+        setAutoRun({ active: true, index: nextIdx });
+        loadScenario(p.nodes, p.layers, p.edges, p.label, p.group);
+      }, AUTORUN_GAP_MS);
+
+      return () => {
+        if (autoTimerRef.current) {
+          clearTimeout(autoTimerRef.current);
+          autoTimerRef.current = null;
+        }
+      };
+    }
+  }, [results, autoRun.active, autoRun.index]);
+
+  // ─── Load scenario ────────────────────────────────────────────────────────
+  function loadScenario(nodes, layers, edges, label, group) {
+    // Reset all state
+    setFps(null);
+    setMemMB(null);
+    setConvMs(null);
+    setElapsed(0);
+    converged.current   = false;
+    resultSaved.current = false;
+    fpsSamples.current  = [];
+    frameCount.current  = 0;
+    lastHalfSec.current = performance.now();
+
+    pendingMeta.current = { label, nodes, layers, edges, group: group ?? 'custom' };
+    benchStart.current  = performance.now();
+
+    onLoadGraph(generateBenchmarkGraph({ nodeCount: nodes, layerCount: layers, edgeCount: edges }));
+    setIsRunning(true);
+  }
+
+  function stopBench() {
+    // Cancel any pending auto-run advancement
+    if (autoTimerRef.current) {
+      clearTimeout(autoTimerRef.current);
+      autoTimerRef.current = null;
+    }
+    setAutoRun({ active: false, index: 0 });
+
+    // Snapshot current metrics if we haven't auto-saved yet
+    if (!resultSaved.current && pendingMeta.current !== null) {
+      const result = {
+        id: ++resultCounter.current,
+        ...pendingMeta.current,
+        fps: fps ?? 0,
+        memMB,
+        convMs,
+        time: new Date().toLocaleTimeString(),
+      };
+      setResults(prev => [result, ...prev.slice(0, 49)]);
+      resultSaved.current = true;
+    }
+    setIsRunning(false);
+  }
+
+  // ─── Run all presets sequentially ─────────────────────────────────────────
+  function runAll() {
+    setResults([]);                         // start with a clean slate
+    lastResultsLen.current = 0;
+    setAutoRun({ active: true, index: 0 });
+    const p = PRESETS[0];
+    loadScenario(p.nodes, p.layers, p.edges, p.label, p.group);
+  }
+
+  // ─── Export helpers ───────────────────────────────────────────────────────
+  function buildMarkdown() {
+    if (results.length === 0) return '';
+
+    // Results are stored newest-first; reverse so the markdown reads in run order
+    const ordered = [...results].reverse();
+
+    const lines = [];
+    lines.push(`## Stress Bench Results — ${new Date().toLocaleString()}`);
+    lines.push('');
+    lines.push('### Environment');
+    lines.push('');
+    lines.push(`- **User agent:** \`${navigator.userAgent}\``);
+    lines.push(`- **CPU cores:** ${navigator.hardwareConcurrency ?? 'unknown'}`);
+    lines.push(`- **Device pixel ratio:** ${window.devicePixelRatio}`);
+    lines.push(`- **Viewport:** ${window.innerWidth}×${window.innerHeight}`);
+    if (performance.memory) {
+      const heapLimitMB = Math.round(performance.memory.jsHeapSizeLimit / 1_048_576);
+      lines.push(`- **JS heap limit:** ~${heapLimitMB.toLocaleString()} MB`);
+    }
+    lines.push('');
+
+    // Group results by category for cleaner markdown
+    const groups = ['nodes', 'density', 'layers', 'custom'];
+    for (const g of groups) {
+      const rows = ordered.filter(r => (r.group ?? 'custom') === g);
+      if (rows.length === 0) continue;
+      lines.push(`### ${groupHeading(g)}`);
+      lines.push('');
+      for (const r of rows) {
+        // Trailing two spaces force a soft line break in markdown so each
+        // field renders on its own line within the same scenario block.
+        lines.push(`**Scenario:** ${r.label}  `);
+        lines.push(`**Nodes:** ${r.nodes.toLocaleString()}  `);
+        lines.push(`**Layers:** ${r.layers}  `);
+        lines.push(`**Edges:** ${r.edges.toLocaleString()}  `);
+        lines.push(`**FPS:** ${r.fps}  `);
+        lines.push(`**Mem (MB):** ${r.memMB ?? '—'}  `);
+        lines.push(`**Conv (ms):** ${r.convMs !== null ? r.convMs.toLocaleString() : '∞'}`);
+        lines.push(''); // blank line separates scenarios
+      }
+    }
+
+    // ── Threshold analysis ───────────────────────────────────────────────
+    lines.push('### Thresholds');
+    lines.push('');
+
+    const tiers = ordered.filter(r => r.group === 'nodes');
+    if (tiers.length > 0) {
+      const lastGood   = [...tiers].reverse().find(r => r.fps >= 30);
+      const firstBad   = tiers.find(r => r.fps < 30);
+      const firstDead  = tiers.find(r => r.fps < 15);
+      const firstNoConv = tiers.find(r => r.convMs === null);
+
+      if (lastGood)    lines.push(`- Last node-count tier with **FPS ≥ 30**: \`${lastGood.label}\` — ${lastGood.fps} fps`);
+      if (firstBad)    lines.push(`- First node-count tier with **FPS < 30**: \`${firstBad.label}\` — ${firstBad.fps} fps (struggling)`);
+      if (firstDead)   lines.push(`- First node-count tier with **FPS < 15** (unusable): \`${firstDead.label}\` — ${firstDead.fps} fps`);
+      if (firstNoConv) lines.push(`- First node-count tier where simulation **never converged** (>30 s): \`${firstNoConv.label}\``);
+      if (!firstBad && !firstDead && !firstNoConv) {
+        lines.push('- All node-count tiers stayed at FPS ≥ 30 and converged within 30 s — no upper bound found.');
+      }
+    } else {
+      lines.push('- _(Run the node-count preset tier to populate threshold analysis.)_');
+    }
+
+    // Density comparison
+    const dens = ordered.filter(r => r.group === 'density');
+    if (dens.length === 2) {
+      const sparse = dens.find(r => r.edges < dens[0].edges + dens[1].edges - r.edges) ?? dens[0];
+      const dense  = dens.find(r => r !== sparse) ?? dens[1];
+      const fpsDelta = sparse.fps - dense.fps;
+      const convDelta = (dense.convMs ?? 0) - (sparse.convMs ?? 0);
+      lines.push('');
+      lines.push(`- **Link-density impact** (500 nodes, ${sparse.edges} → ${dense.edges} edges): FPS dropped by ${fpsDelta}, convergence ${convDelta > 0 ? `slowed by ${convDelta.toLocaleString()} ms` : `was ${Math.abs(convDelta).toLocaleString()} ms faster`}.`);
+    }
+
+    // Layer extremes
+    const layers = ordered.filter(r => r.group === 'layers');
+    if (layers.length > 0) {
+      lines.push('');
+      lines.push('- **Layer extremes:** see scenario blocks above. Note manually whether camera framing, zoom, and rotation remained usable.');
+    }
+
+    lines.push('');
+    lines.push('_Generated by StressBench. FPS measured via requestAnimationFrame; memory via `performance.memory.usedJSHeapSize` (Chromium only); convergence detected when FPS spread ≤ 3 over 4 consecutive 500 ms windows or after a 30 s timeout._');
+
+    return lines.join('\n');
+  }
+
+  function copyMarkdown() {
+    const md = buildMarkdown();
+    if (!md) return;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(md).then(
+        () => flashNotice('✓ Markdown copied to clipboard'),
+        () => downloadFile('stress-bench.md', md),
+      );
+    } else {
+      downloadFile('stress-bench.md', md);
+    }
+  }
+
+  function exportJSON() {
+    if (results.length === 0) return;
+    const payload = {
+      generatedAt: new Date().toISOString(),
+      env: {
+        userAgent: navigator.userAgent,
+        hardwareConcurrency: navigator.hardwareConcurrency ?? null,
+        devicePixelRatio: window.devicePixelRatio,
+        viewport: { w: window.innerWidth, h: window.innerHeight },
+      },
+      results: [...results].reverse(),
+    };
+    downloadFile('stress-bench.json', JSON.stringify(payload, null, 2));
+    flashNotice('✓ JSON downloaded');
+  }
+
+  function flashNotice(msg) {
+    setExportNotice(msg);
+    setTimeout(() => setExportNotice(''), 2200);
+  }
+
+  function downloadFile(filename, content) {
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+  const liveFpsTier = !isRunning ? 'dim' : tierFor(fps);
+  const memTier     = !isRunning || memMB === null ? 'dim' : 'blue';
+  const convTier    = !isRunning ? 'dim' : (convMs === null && converged.current ? 'bad' : 'blue');
+
+  return (
+    <div className="sb-root">
+      {/* ── Header ── */}
+      <div className="sb-header">
+        <span className="sb-title">⚡ STRESS BENCH</span>
+        <button className="sb-collapse-btn" onClick={() => setOpen(v => !v)}>
+          {open ? '▾' : '▸'}
+        </button>
+      </div>
+
+      {/* ── Live metrics bar (always visible) ── */}
+      <div className="sb-metrics-row">
+        <MetricBox label="FPS"      value={fps   ?? '—'} tier={liveFpsTier} />
+        <MetricBox label="MEM MB"   value={memMB ?? '—'} tier={memTier}     />
+        <MetricBox
+          label="CONV ms"
+          value={
+            !isRunning          ? '—'        :
+            convMs !== null     ? convMs      :
+            converged.current   ? '∞'         :
+            `${elapsed}s…`
+          }
+          tier={convTier}
+        />
+      </div>
+
+      {/* Auto-run progress / stop */}
+      {autoRun.active && (
+        <div className="sb-autorun-bar">
+          <div className="sb-autorun-label">
+            ⏵ Auto-run {autoRun.index + 1}/{PRESETS.length}: {PRESETS[autoRun.index].label}
+          </div>
+          <button className="sb-btn sb-btn--stop" style={{ marginTop: 4 }} onClick={stopBench}>
+            ■ Stop auto-run
+          </button>
+        </div>
+      )}
+
+      {open && (
+        <>
+          {/* ── Run All button ── */}
+          <div className="sb-group">
+            <button
+              className="sb-btn sb-btn--run-all"
+              onClick={runAll}
+              disabled={autoRun.active}
+            >
+              ▶▶ Run all 8 presets
+            </button>
+          </div>
+
+          {/* ── Preset groups ── */}
+          {['nodes', 'density', 'layers'].map(group => (
+            <div key={group} className="sb-group">
+              <div className="sb-group-label">{GROUP_LABELS[group]}</div>
+              {PRESETS.filter(p => p.group === group).map((p, i) => (
+                <button
+                  key={i}
+                  className="sb-btn"
+                  onClick={() => loadScenario(p.nodes, p.layers, p.edges, p.label, p.group)}
+                  disabled={autoRun.active}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          ))}
+
+          {/* ── Custom sliders ── */}
+          <div className="sb-group">
+            <div className="sb-group-label">✦ Custom</div>
+            <SliderRow
+              label={`Nodes: ${customNodes.toLocaleString()}`}
+              min={1} max={6000} step={1}
+              value={customNodes} onChange={setCustomNodes}
+            />
+            <SliderRow
+              label={`Layers: ${customLayers}`}
+              min={1} max={60} step={1}
+              value={customLayers} onChange={setCustomLayers}
+            />
+            <SliderRow
+              label={`Edges: ${customEdges.toLocaleString()}`}
+              min={0} max={10000} step={50}
+              value={customEdges} onChange={setCustomEdges}
+            />
+            <div className="sb-btn-row">
+              <button
+                className="sb-btn sb-btn--run"
+                onClick={() =>
+                  loadScenario(
+                    customNodes, customLayers, customEdges,
+                    `${customNodes}n·${customLayers}L·${customEdges}E`,
+                    'custom',
+                  )
+                }
+                disabled={autoRun.active}
+              >
+                ▶ Run
+              </button>
+              {isRunning && !autoRun.active && (
+                <button className="sb-btn sb-btn--stop" onClick={stopBench}>
+                  ■ Stop
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* ── Results table + export ── */}
+          {results.length > 0 && (
+            <div className="sb-group">
+              <div className="sb-results-header">
+                <div className="sb-group-label">📋 Results ({results.length})</div>
+                <button className="sb-clear-btn" onClick={() => setResults([])}>clear</button>
+              </div>
+
+              {/* Export buttons */}
+              <div className="sb-export-row">
+                <button className="sb-btn sb-btn--export" onClick={copyMarkdown}>
+                  📝 Copy MD
+                </button>
+                <button className="sb-btn sb-btn--export" onClick={exportJSON}>
+                  💾 Export JSON
+                </button>
+              </div>
+              {exportNotice && <div className="sb-notice">{exportNotice}</div>}
+
+              <div className="sb-table-wrap">
+                <table className="sb-table">
+                  <thead>
+                    <tr>
+                      {['#', 'Scenario', 'N', 'L', 'E', 'FPS', 'MEM', 'Conv ms'].map(h => (
+                        <th key={h}>{h}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {results.map(r => (
+                      <tr key={r.id}>
+                        <td>{r.id}</td>
+                        <td className="sb-cell--scenario" title={r.label}>{r.label}</td>
+                        <td>{r.nodes.toLocaleString()}</td>
+                        <td>{r.layers}</td>
+                        <td>{r.edges.toLocaleString()}</td>
+                        <td className={`sb-cell--fps sb-tier-${tierFor(r.fps)}`}>{r.fps}</td>
+                        <td>{r.memMB ?? '—'}</td>
+                        <td className={r.convMs === null ? 'sb-tier-bad' : ''}>
+                          {r.convMs !== null ? r.convMs.toLocaleString() : '∞'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Threshold legend */}
+              <div className="sb-hint">
+                FPS colours: <span className="sb-tier-good">≥50 good</span>{' · '}
+                <span className="sb-tier-ok">30–49 ok</span>{' · '}
+                <span className="sb-tier-bad">15–29 struggling</span>{' · '}
+                <span className="sb-tier-dead">&lt;15 unusable</span>
+                {' · '}Conv ∞ = never converged (&gt;30 s)
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function MetricBox({ label, value, tier }) {
+  return (
+    <div className={`sb-metric-box sb-tier-${tier}`}>
+      <div className="sb-metric-label">{label}</div>
+      <div className={`sb-metric-value sb-tier-${tier}`}>{value}</div>
+    </div>
+  );
+}
+
+function SliderRow({ label, min, max, step, value, onChange }) {
+  return (
+    <div className="sb-slider-row">
+      <div className="sb-slider-label">{label}</div>
+      <input
+        type="range" min={min} max={max} step={step} value={value}
+        onChange={e => onChange(Number(e.target.value))}
+        className="sb-slider"
+      />
+    </div>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Map an fps number (or null) to one of the tier modifier-class suffixes. */
+function tierFor(fps) {
+  if (fps === null || fps === undefined) return 'idle';
+  if (fps < 15) return 'dead';
+  if (fps < 30) return 'bad';
+  if (fps < 50) return 'ok';
+  return 'good';
+}
+
+function groupHeading(g) {
+  if (g === 'nodes')   return 'Node count tiers';
+  if (g === 'density') return 'Link density (500 nodes)';
+  if (g === 'layers')  return 'Layer extremes';
+  return 'Custom runs';
+}

--- a/src/data/benchmarkDataGenerator.js
+++ b/src/data/benchmarkDataGenerator.js
@@ -1,0 +1,93 @@
+/**
+ * benchmarkDataGenerator.js
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Generates synthetic graph data in the *internal* shape the renderer expects
+ * (the same shape `parseAnyGraphInput` produces), so it can be fed straight
+ * into setGraphData() without going through file-upload validation.
+ *
+ * Internal shape (matches App.jsx + GraphView usage):
+ *   {
+ *     nodes: [{ id, label, layer, weight, frequency, metadata }, ...],
+ *     links: [{ source, target }, ...],   // source/target are string node ids
+ *   }
+ *
+ * @typedef {Object} BenchmarkParams
+ * @property {number} nodeCount   Total number of nodes
+ * @property {number} layerCount  Number of distinct layers (min 1)
+ * @property {number} edgeCount   Desired forward-edge count (duplicates skipped)
+ */
+
+/**
+ * @param {BenchmarkParams} params
+ */
+export function generateBenchmarkGraph(params) {
+  const { nodeCount, edgeCount } = params;
+  const layerCount = Math.max(1, params.layerCount);
+
+  // ── Nodes ───────────────────────────────────────────────────────────────
+  // Distribute nodes as evenly as possible across layers using round-robin so
+  // no layer is ever empty (important for the single-layer repulsion test).
+  const nodes = Array.from({ length: nodeCount }, (_, i) => {
+    const freq = Math.floor(lcgRand(i + 1) * 99) + 1; // deterministic [1,100]
+    return {
+      id: `bn-${i}`,
+      label: `N${i}`,
+      layer: i % layerCount,           // <-- internal field name (singular)
+      weight: freq,
+      frequency: freq,                  // some renderers read this flat
+      metadata: { frequency: freq },    // ...others read it nested
+    };
+  });
+
+  // Build a lookup: layer → [nodeId, …] for edge sampling
+  const byLayer = Array.from({ length: layerCount }, () => []);
+  for (const n of nodes) byLayer[n.layer].push(n.id);
+
+  // ── Links ───────────────────────────────────────────────────────────────
+  const links = [];
+
+  // Single-layer graphs cannot have forward links (DAG constraint).
+  if (layerCount > 1 && edgeCount > 0) {
+    const linkSet = new Set();
+    // Cap attempts so we don't block on impossible-to-fill graphs
+    const maxAttempts = Math.min(edgeCount * 8, 200_000);
+    let seed = 42;
+
+    for (let attempt = 0; attempt < maxAttempts && links.length < edgeCount; attempt++) {
+      // Pick source layer in [0, layerCount-2] and a strictly later target layer
+      seed = lcgStep(seed);
+      const srcLayerIdx = seed % (layerCount - 1);
+      seed = lcgStep(seed);
+      const tgtLayerIdx = srcLayerIdx + 1 + (seed % (layerCount - 1 - srcLayerIdx));
+
+      const srcBucket = byLayer[srcLayerIdx];
+      const tgtBucket = byLayer[tgtLayerIdx];
+      if (srcBucket.length === 0 || tgtBucket.length === 0) continue;
+
+      seed = lcgStep(seed);
+      const source = srcBucket[seed % srcBucket.length];
+      seed = lcgStep(seed);
+      const target = tgtBucket[seed % tgtBucket.length];
+
+      const key = `${source}→${target}`;
+      if (!linkSet.has(key)) {
+        linkSet.add(key);
+        links.push({ source, target });
+      }
+    }
+  }
+
+  return { nodes, links };
+}
+
+// ─── Tiny deterministic LCG (no Math.random so results are reproducible) ────
+
+function lcgStep(s) {
+  // Parameters from Numerical Recipes
+  return ((s * 1664525 + 1013904223) >>> 0); // unsigned 32-bit
+}
+
+/** Returns a value in [0, 1) from a seed index (not a state) */
+function lcgRand(index) {
+  return (lcgStep(index) / 0xffffffff);
+}

--- a/src/data/benchmarkDataGenerator.js
+++ b/src/data/benchmarkDataGenerator.js
@@ -4,71 +4,44 @@
  * Generates synthetic graph data in the *internal* shape the renderer expects
  * (the same shape `parseAnyGraphInput` produces), so it can be fed straight
  * into setGraphData() without going through file-upload validation.
- *
- * Internal shape (matches App.jsx + GraphView usage):
- *   {
- *     nodes: [{ id, label, layer, weight, frequency, metadata }, ...],
- *     links: [{ source, target }, ...],   // source/target are string node ids
- *   }
- *
- * @typedef {Object} BenchmarkParams
- * @property {number} nodeCount   Total number of nodes
- * @property {number} layerCount  Number of distinct layers (min 1)
- * @property {number} edgeCount   Desired forward-edge count (duplicates skipped)
  */
 
-/**
- * @param {BenchmarkParams} params
- */
 export function generateBenchmarkGraph(params) {
   const { nodeCount, edgeCount } = params;
   const layerCount = Math.max(1, params.layerCount);
 
-  // ── Nodes ───────────────────────────────────────────────────────────────
-  // Distribute nodes as evenly as possible across layers using round-robin so
-  // no layer is ever empty (important for the single-layer repulsion test).
   const nodes = Array.from({ length: nodeCount }, (_, i) => {
-    const freq = Math.floor(lcgRand(i + 1) * 99) + 1; // deterministic [1,100]
+    const freq = Math.floor(lcgRand(i + 1) * 99) + 1;
     return {
       id: `bn-${i}`,
       label: `N${i}`,
-      layer: i % layerCount,           // <-- internal field name (singular)
+      layer: i % layerCount,
       weight: freq,
-      frequency: freq,                  // some renderers read this flat
-      metadata: { frequency: freq },    // ...others read it nested
+      frequency: freq,
+      metadata: { frequency: freq },
     };
   });
 
-  // Build a lookup: layer → [nodeId, …] for edge sampling
   const byLayer = Array.from({ length: layerCount }, () => []);
   for (const n of nodes) byLayer[n.layer].push(n.id);
 
-  // ── Links ───────────────────────────────────────────────────────────────
   const links = [];
-
-  // Single-layer graphs cannot have forward links (DAG constraint).
   if (layerCount > 1 && edgeCount > 0) {
     const linkSet = new Set();
-    // Cap attempts so we don't block on impossible-to-fill graphs
     const maxAttempts = Math.min(edgeCount * 8, 200_000);
     let seed = 42;
-
     for (let attempt = 0; attempt < maxAttempts && links.length < edgeCount; attempt++) {
-      // Pick source layer in [0, layerCount-2] and a strictly later target layer
       seed = lcgStep(seed);
       const srcLayerIdx = seed % (layerCount - 1);
       seed = lcgStep(seed);
       const tgtLayerIdx = srcLayerIdx + 1 + (seed % (layerCount - 1 - srcLayerIdx));
-
       const srcBucket = byLayer[srcLayerIdx];
       const tgtBucket = byLayer[tgtLayerIdx];
       if (srcBucket.length === 0 || tgtBucket.length === 0) continue;
-
       seed = lcgStep(seed);
       const source = srcBucket[seed % srcBucket.length];
       seed = lcgStep(seed);
       const target = tgtBucket[seed % tgtBucket.length];
-
       const key = `${source}→${target}`;
       if (!linkSet.has(key)) {
         linkSet.add(key);
@@ -80,14 +53,5 @@ export function generateBenchmarkGraph(params) {
   return { nodes, links };
 }
 
-// ─── Tiny deterministic LCG (no Math.random so results are reproducible) ────
-
-function lcgStep(s) {
-  // Parameters from Numerical Recipes
-  return ((s * 1664525 + 1013904223) >>> 0); // unsigned 32-bit
-}
-
-/** Returns a value in [0, 1) from a seed index (not a state) */
-function lcgRand(index) {
-  return (lcgStep(index) / 0xffffffff);
-}
+function lcgStep(s) { return ((s * 1664525 + 1013904223) >>> 0); }
+function lcgRand(index) { return (lcgStep(index) / 0xffffffff); }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -519,54 +519,50 @@ select:hover {
    Benchmark HUD styles
    ======================================== */
 
-/* ── Container ─────────────────────────────────────────────────────────── */
-
-.sb-root {
-  position: fixed;
-  top: 12px;
-  left: 12px;
-  z-index: 9999;
-  width: 320px;
-  max-height: 92vh;
-  overflow-y: auto;
-  background: rgba(9, 11, 17, 0.93);
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 10px;
-  padding: 12px 14px;
+/* ── Tab switcher (rendered by ControlPanel) ─────────────────────────── */
+ 
+.panel-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 16px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  margin-bottom: 12px;
+}
+.panel-tab {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  color: #94a3b8;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  font-family: var(--sb-mono);
+  letter-spacing: 0.04em;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.panel-tab:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #cbd5e1;
+}
+.panel-tab.active {
+  background: rgba(129, 140, 248, 0.15);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: var(--sb-purple);
+  font-weight: 600;
+}
+ 
+/* ── Inline container (lives inside ControlPanel) ─────────────────────── */
+ 
+.sb-inline {
   font-family: var(--sb-mono);
   font-size: 11px;
   color: #cbd5e1;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  padding: 0 16px 16px;
 }
-
-/* ── Header ────────────────────────────────────────────────────────────── */
-
-.sb-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 10px;
-}
-.sb-title {
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  color: var(--sb-purple);
-  text-transform: uppercase;
-}
-.sb-collapse-btn {
-  background: none;
-  border: none;
-  color: #64748b;
-  cursor: pointer;
-  font-size: 14px;
-  line-height: 1;
-  padding: 0 2px;
-}
-
+ 
 /* ── Metrics row ──────────────────────────────────────────────────────── */
-
+ 
 .sb-metrics-row {
   display: flex;
   gap: 8px;
@@ -591,33 +587,32 @@ select:hover {
   font-size: 17px;
   font-weight: 700;
 }
-
+ 
 /* ── Tier modifiers (apply to .sb-metric-box, .sb-metric-value, table cells, hint legend) ── */
-
-/* When dim: keep grey text, hide accent border */
+ 
 .sb-tier-dim          { color: var(--sb-fps-idle); }
 .sb-metric-box.sb-tier-dim { border-color: transparent; }
-
+ 
 .sb-tier-idle         { color: var(--sb-fps-idle); }
 .sb-metric-box.sb-tier-idle { border-color: var(--sb-fps-idle); }
-
+ 
 .sb-tier-good         { color: var(--sb-fps-good); }
 .sb-metric-box.sb-tier-good { border-color: var(--sb-fps-good); }
-
+ 
 .sb-tier-ok           { color: var(--sb-fps-ok); }
 .sb-metric-box.sb-tier-ok   { border-color: var(--sb-fps-ok); }
-
+ 
 .sb-tier-bad          { color: var(--sb-fps-bad); }
 .sb-metric-box.sb-tier-bad  { border-color: var(--sb-fps-bad); }
-
+ 
 .sb-tier-dead         { color: var(--sb-fps-dead); }
 .sb-metric-box.sb-tier-dead { border-color: var(--sb-fps-dead); }
-
+ 
 .sb-tier-blue         { color: var(--sb-blue); }
 .sb-metric-box.sb-tier-blue { border-color: var(--sb-blue); }
-
+ 
 /* ── Auto-run progress ────────────────────────────────────────────────── */
-
+ 
 .sb-autorun-bar {
   background: rgba(45, 212, 191, 0.08);
   border: 1px solid rgba(45, 212, 191, 0.3);
@@ -630,9 +625,9 @@ select:hover {
   color: var(--sb-teal);
   letter-spacing: 0.04em;
 }
-
+ 
 /* ── Groups ───────────────────────────────────────────────────────────── */
-
+ 
 .sb-group         { margin-bottom: 12px; }
 .sb-group-label {
   font-size: 9px;
@@ -641,9 +636,9 @@ select:hover {
   text-transform: uppercase;
   margin-bottom: 5px;
 }
-
+ 
 /* ── Buttons (base + modifiers) ────────────────────────────────────────── */
-
+ 
 .sb-btn {
   display: block;
   width: 100%;
@@ -667,7 +662,7 @@ select:hover {
   opacity: 0.4;
   cursor: not-allowed;
 }
-
+ 
 .sb-btn--run-all {
   background: rgba(45, 212, 191, 0.15);
   border-color: rgba(45, 212, 191, 0.4);
@@ -703,12 +698,12 @@ select:hover {
   font-weight: 600;
   margin-bottom: 0;
 }
-
+ 
 .sb-btn-row     { display: flex; gap: 6px; margin-top: 8px; }
 .sb-export-row  { display: flex; gap: 6px; margin-bottom: 6px; }
-
+ 
 /* ── Notice toast ─────────────────────────────────────────────────────── */
-
+ 
 .sb-notice {
   font-size: 10px;
   color: var(--sb-teal);
@@ -718,9 +713,9 @@ select:hover {
   border-radius: 4px;
   padding: 3px 6px;
 }
-
+ 
 /* ── Slider ───────────────────────────────────────────────────────────── */
-
+ 
 .sb-slider-row   { margin-bottom: 6px; }
 .sb-slider-label { font-size: 10px; color: #94a3b8; margin-bottom: 2px; }
 .sb-slider {
@@ -728,9 +723,9 @@ select:hover {
   accent-color: var(--sb-purple);
   cursor: pointer;
 }
-
+ 
 /* ── Results table ────────────────────────────────────────────────────── */
-
+ 
 .sb-results-header {
   display: flex;
   justify-content: space-between;
@@ -747,7 +742,7 @@ select:hover {
   padding: 0;
 }
 .sb-clear-btn:hover { color: #cbd5e1; }
-
+ 
 .sb-table-wrap { overflow-x: auto; }
 .sb-table {
   width: 100%;
@@ -775,12 +770,13 @@ select:hover {
   white-space: nowrap;
 }
 .sb-cell--fps   { font-weight: 600; }
-
+ 
 /* ── Hint legend ──────────────────────────────────────────────────────── */
-
+ 
 .sb-hint {
   margin-top: 8px;
   font-size: 9px;
   color: #334155;
   line-height: 1.6;
 }
+ 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -514,3 +514,273 @@ select:hover {
   top: -9px;
   left: 0;
 }
+
+/* ========================================
+   Benchmark HUD styles
+   ======================================== */
+
+/* ── Container ─────────────────────────────────────────────────────────── */
+
+.sb-root {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 9999;
+  width: 320px;
+  max-height: 92vh;
+  overflow-y: auto;
+  background: rgba(9, 11, 17, 0.93);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-family: var(--sb-mono);
+  font-size: 11px;
+  color: #cbd5e1;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+/* ── Header ────────────────────────────────────────────────────────────── */
+
+.sb-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.sb-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--sb-purple);
+  text-transform: uppercase;
+}
+.sb-collapse-btn {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+/* ── Metrics row ──────────────────────────────────────────────────────── */
+
+.sb-metrics-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.sb-metric-box {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;        /* recoloured by .sb-tier-* below */
+  border-radius: 6px;
+  padding: 6px 8px;
+  text-align: center;
+  transition: border-color 0.3s;
+}
+.sb-metric-label {
+  font-size: 9px;
+  color: #475569;
+  letter-spacing: 0.08em;
+  margin-bottom: 3px;
+}
+.sb-metric-value {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+/* ── Tier modifiers (apply to .sb-metric-box, .sb-metric-value, table cells, hint legend) ── */
+
+/* When dim: keep grey text, hide accent border */
+.sb-tier-dim          { color: var(--sb-fps-idle); }
+.sb-metric-box.sb-tier-dim { border-color: transparent; }
+
+.sb-tier-idle         { color: var(--sb-fps-idle); }
+.sb-metric-box.sb-tier-idle { border-color: var(--sb-fps-idle); }
+
+.sb-tier-good         { color: var(--sb-fps-good); }
+.sb-metric-box.sb-tier-good { border-color: var(--sb-fps-good); }
+
+.sb-tier-ok           { color: var(--sb-fps-ok); }
+.sb-metric-box.sb-tier-ok   { border-color: var(--sb-fps-ok); }
+
+.sb-tier-bad          { color: var(--sb-fps-bad); }
+.sb-metric-box.sb-tier-bad  { border-color: var(--sb-fps-bad); }
+
+.sb-tier-dead         { color: var(--sb-fps-dead); }
+.sb-metric-box.sb-tier-dead { border-color: var(--sb-fps-dead); }
+
+.sb-tier-blue         { color: var(--sb-blue); }
+.sb-metric-box.sb-tier-blue { border-color: var(--sb-blue); }
+
+/* ── Auto-run progress ────────────────────────────────────────────────── */
+
+.sb-autorun-bar {
+  background: rgba(45, 212, 191, 0.08);
+  border: 1px solid rgba(45, 212, 191, 0.3);
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-bottom: 10px;
+}
+.sb-autorun-label {
+  font-size: 10px;
+  color: var(--sb-teal);
+  letter-spacing: 0.04em;
+}
+
+/* ── Groups ───────────────────────────────────────────────────────────── */
+
+.sb-group         { margin-bottom: 12px; }
+.sb-group-label {
+  font-size: 9px;
+  color: #475569;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 5px;
+}
+
+/* ── Buttons (base + modifiers) ────────────────────────────────────────── */
+
+.sb-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  color: #94a3b8;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 10px;
+  font-family: var(--sb-mono);
+  margin-bottom: 3px;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.sb-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  color: #cbd5e1;
+}
+.sb-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.sb-btn--run-all {
+  background: rgba(45, 212, 191, 0.15);
+  border-color: rgba(45, 212, 191, 0.4);
+  color: var(--sb-teal);
+  font-weight: 700;
+  text-align: center;
+  padding: 6px 8px;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+}
+.sb-btn--run {
+  flex: 1;
+  background: rgba(99, 102, 241, 0.2);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: var(--sb-purple);
+  font-weight: 600;
+  text-align: center;
+}
+.sb-btn--stop {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: var(--sb-fps-dead);
+  font-weight: 600;
+  padding: 4px 12px;
+  text-align: center;
+}
+.sb-btn--export {
+  flex: 1;
+  text-align: center;
+  background: rgba(56, 189, 248, 0.1);
+  border-color: rgba(56, 189, 248, 0.3);
+  color: var(--sb-blue);
+  font-weight: 600;
+  margin-bottom: 0;
+}
+
+.sb-btn-row     { display: flex; gap: 6px; margin-top: 8px; }
+.sb-export-row  { display: flex; gap: 6px; margin-bottom: 6px; }
+
+/* ── Notice toast ─────────────────────────────────────────────────────── */
+
+.sb-notice {
+  font-size: 10px;
+  color: var(--sb-teal);
+  margin-bottom: 6px;
+  text-align: center;
+  background: rgba(45, 212, 191, 0.08);
+  border-radius: 4px;
+  padding: 3px 6px;
+}
+
+/* ── Slider ───────────────────────────────────────────────────────────── */
+
+.sb-slider-row   { margin-bottom: 6px; }
+.sb-slider-label { font-size: 10px; color: #94a3b8; margin-bottom: 2px; }
+.sb-slider {
+  width: 100%;
+  accent-color: var(--sb-purple);
+  cursor: pointer;
+}
+
+/* ── Results table ────────────────────────────────────────────────────── */
+
+.sb-results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.sb-clear-btn {
+  background: none;
+  border: none;
+  color: #475569;
+  cursor: pointer;
+  font-size: 10px;
+  font-family: var(--sb-mono);
+  padding: 0;
+}
+.sb-clear-btn:hover { color: #cbd5e1; }
+
+.sb-table-wrap { overflow-x: auto; }
+.sb-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10px;
+}
+.sb-table th {
+  text-align: left;
+  color: #475569;
+  padding-bottom: 4px;
+  padding-right: 6px;
+  white-space: nowrap;
+}
+.sb-table tr {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+.sb-table td {
+  padding: 3px 6px 3px 0;
+  white-space: nowrap;
+}
+.sb-cell--scenario {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sb-cell--fps   { font-weight: 600; }
+
+/* ── Hint legend ──────────────────────────────────────────────────────── */
+
+.sb-hint {
+  margin-top: 8px;
+  font-size: 9px;
+  color: #334155;
+  line-height: 1.6;
+}


### PR DESCRIPTION
Added benchmarking tab that can simulate custom amount of nodes, edges, and layers to test application limits. Measure real-time metrics of FPS, memory usage, (MB) and convergence time (ms). 8 built in benchmarking presets with varying node, edge, and layers to standardize testing.

Lastly saves values and formats to either .md or .json.
Following is .md report generated on my Laptop:

## Stress Bench Results — 4/30/2026, 6:47:16 PM

### Environment

- **User agent:** `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36`
- **CPU cores:** 4
- **Device pixel ratio:** 2
- **Viewport:** 1440×812
- **JS heap limit:** ~4,096 MB

### Node count tiers

**Scenario:** 50 nodes · 3 L · 75 E  
**Nodes:** 50  
**Layers:** 3  
**Edges:** 75  
**FPS:** 56  
**Mem (MB):** 30  
**Conv (ms):** 3,043

**Scenario:** 200 nodes · 5 L · 400 E  
**Nodes:** 200  
**Layers:** 5  
**Edges:** 400  
**FPS:** 45  
**Mem (MB):** 73  
**Conv (ms):** 2,789

**Scenario:** 1 000 nodes · 8 L · 2 000 E  
**Nodes:** 1,000  
**Layers:** 8  
**Edges:** 2,000  
**FPS:** 12  
**Mem (MB):** 281  
**Conv (ms):** 5,857

**Scenario:** 5 000 nodes · 8 L · 5 000 E  
**Nodes:** 5,000  
**Layers:** 8  
**Edges:** 5,000  
**FPS:** 1  
**Mem (MB):** 1148  
**Conv (ms):** 22,084

### Link density (500 nodes)

**Scenario:** 500 nodes · 5 L · 50 E  
**Nodes:** 500  
**Layers:** 5  
**Edges:** 50  
**FPS:** 1  
**Mem (MB):** 1040  
**Conv (ms):** 4,673

**Scenario:** 500 nodes · 5 L · 5 000 E  
**Nodes:** 500  
**Layers:** 5  
**Edges:** 5,000  
**FPS:** 15  
**Mem (MB):** 1109  
**Conv (ms):** 4,850

### Layer extremes

**Scenario:** 200 nodes · 1 L (repulsion)  
**Nodes:** 200  
**Layers:** 1  
**Edges:** 0  
**FPS:** 39  
**Mem (MB):** 1147  
**Conv (ms):** 12,959

**Scenario:** 200 nodes · 50 L · 300 E  
**Nodes:** 200  
**Layers:** 50  
**Edges:** 300  
**FPS:** 46  
**Mem (MB):** 1196  
**Conv (ms):** 3,654

### Thresholds

- Last node-count tier with **FPS ≥ 30**: `200 nodes · 5 L · 400 E` — 45 fps
- First node-count tier with **FPS < 30**: `1 000 nodes · 8 L · 2 000 E` — 12 fps (struggling)
- First node-count tier with **FPS < 15** (unusable): `1 000 nodes · 8 L · 2 000 E` — 12 fps

- **Link-density impact** (500 nodes, 50 → 5000 edges): FPS dropped by -14, convergence slowed by 177 ms.

- **Layer extremes:** see scenario blocks above. Note manually whether camera framing, zoom, and rotation remained usable.

_Generated by StressBench. FPS measured via requestAnimationFrame; memory via `performance.memory.usedJSHeapSize` (Chromium only); convergence detected when FPS spread ≤ 3 over 4 consecutive 500 ms windows or after a 30 s timeout._